### PR TITLE
Pass scope variable to substrate-benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             pip install -r w3f/substrate-benchmarks/requirements.txt
       - run:
           name: benchmark e2-micro
-          command: ansible-playbook --extra-vars "machine_type=e2-micro" w3f/substrate-benchmarks/benchmarks.yaml
+          command: ansible-playbook --extra-vars "machine_type=e2-micro scope=limited" w3f/substrate-benchmarks/benchmarks.yaml
           no_output_timeout: 120h
           environment:
             ANSIBLE_HOST_KEY_CHECKING: False
@@ -41,7 +41,7 @@ jobs:
             pip install -r w3f/substrate-benchmarks/requirements.txt
       - run:
           name: benchmark e2-small
-          command: ansible-playbook --extra-vars "machine_type=e2-small" w3f/substrate-benchmarks/benchmarks.yaml
+          command: ansible-playbook --extra-vars "machine_type=e2-small scope=limited" w3f/substrate-benchmarks/benchmarks.yaml
           no_output_timeout: 120h
           environment:
             ANSIBLE_HOST_KEY_CHECKING: False
@@ -59,7 +59,7 @@ jobs:
             pip install -r w3f/substrate-benchmarks/requirements.txt
       - run:
           name: benchmark e2-medium
-          command: ansible-playbook --extra-vars "machine_type=e2-medium" w3f/substrate-benchmarks/benchmarks.yaml
+          command: ansible-playbook --extra-vars "machine_type=e2-medium scope=limited" w3f/substrate-benchmarks/benchmarks.yaml
           no_output_timeout: 120h
           environment:
             ANSIBLE_HOST_KEY_CHECKING: False
@@ -77,7 +77,7 @@ jobs:
             pip install -r w3f/substrate-benchmarks/requirements.txt
       - run:
           name: benchmark n1-standard-1
-          command: ansible-playbook --extra-vars "machine_type=n1-standard-1" w3f/substrate-benchmarks/benchmarks.yaml
+          command: ansible-playbook --extra-vars "machine_type=n1-standard-1 scope=all" w3f/substrate-benchmarks/benchmarks.yaml
           no_output_timeout: 120h
           environment:
             ANSIBLE_HOST_KEY_CHECKING: False
@@ -95,7 +95,7 @@ jobs:
             pip install -r w3f/substrate-benchmarks/requirements.txt
       - run:
           name: benchmark n1-standard-2
-          command: ansible-playbook --extra-vars "machine_type=n1-standard-2" w3f/substrate-benchmarks/benchmarks.yaml
+          command: ansible-playbook --extra-vars "machine_type=n1-standard-2 scope=all" w3f/substrate-benchmarks/benchmarks.yaml
           no_output_timeout: 120h
           environment:
             ANSIBLE_HOST_KEY_CHECKING: False

--- a/w3f/substrate-benchmarks/benchmarks.yaml
+++ b/w3f/substrate-benchmarks/benchmarks.yaml
@@ -39,6 +39,8 @@
   - ping:
   - include_role:
       name: substrate-benchmarks
+    vars:
+      scope: "{{ scope }}"
 
 - name: Clean
   hosts: localhost


### PR DESCRIPTION
Depending on the machine type, pass a different `scope` value for conditional execution of benchmark types. Related to https://github.com/w3f/polkadot-module-benchmarking/pull/2 .